### PR TITLE
Implement floating point support at the lexer and (partially) runtime level

### DIFF
--- a/src/main/kotlin/org/medaware/anterogradia/Util.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/Util.kt
@@ -1,5 +1,6 @@
 package org.medaware.anterogradia
 
+import org.medaware.anterogradia.exception.AntgRuntimeException
 import org.medaware.anterogradia.runtime.Runtime
 import org.medaware.anterogradia.syntax.Node
 
@@ -20,6 +21,30 @@ fun <T> Boolean.map(`if`: T, `else`: T) = if (this) `if` else `else`
 fun Pair<Double, Double>.min() = if (this.first < this.second) this.first else this.second
 
 fun Pair<Double, Double>.max() = if (this.first > this.second) this.first else this.second
+
+inline fun <reified T> String.antgNumber(): T {
+    if (T::class != Double::class && T::class != Int::class)
+        throw AntgRuntimeException("The type '${T::class.java.simpleName}' is not a valid conversion type for a number")
+
+    val double = this.toDouble()
+
+    if (T::class == Int::class && (double % 1 != 0.0))
+        throw AntgRuntimeException("Expected number to be of an effective integer type, got double ($double)")
+
+    return when (T::class) {
+        Double::class -> double
+        Int::class -> double.toInt()
+        else -> throw AntgRuntimeException("")
+    } as T
+}
+
+inline fun <reified T> String.antgNumberOrNull(): T? {
+    return try {
+        antgNumber<T>()
+    } catch (nfe: NumberFormatException) {
+        null
+    }
+}
 
 fun Throwable.rootCause(): Throwable {
     var cause = this

--- a/src/main/kotlin/org/medaware/anterogradia/Util.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/Util.kt
@@ -34,7 +34,7 @@ inline fun <reified T> String.antgNumber(): T {
     return when (T::class) {
         Double::class -> double
         Int::class -> double.toInt()
-        else -> throw AntgRuntimeException("")
+        else -> throw AntgRuntimeException("") // Won't happen
     } as T
 }
 

--- a/src/main/kotlin/org/medaware/anterogradia/libs/Standard.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/libs/Standard.kt
@@ -1,5 +1,7 @@
 package org.medaware.anterogradia.libs
 
+import org.medaware.anterogradia.antgNumber
+import org.medaware.anterogradia.antgNumberOrNull
 import org.medaware.anterogradia.exception.AntgRuntimeException
 import org.medaware.anterogradia.hasNonNullEntry
 import org.medaware.anterogradia.hasNullEntry
@@ -43,14 +45,14 @@ class Standard(val runtime: Runtime) {
 
     @DiscreteFunction(identifier = "repeat", params = ["count", "str"])
     fun repeat(count: Node, str: Node) = try {
-        List(count.evaluate(runtime).toInt()) { str.evaluate(runtime) }.joinToString(separator = "")
+        List(count.evaluate(runtime).antgNumber<Int>()) { str.evaluate(runtime) }.joinToString(separator = "")
     } catch (e: NumberFormatException) {
         str.evaluate(runtime)
     }
 
     @DiscreteFunction(identifier = "repeat", params = ["count", "str", "separator"])
     fun repeat(count: Node, str: Node, separator: Node) = try {
-        List(count.evaluate(runtime).toInt()) { str.evaluate(runtime) }.joinToString(
+        List(count.evaluate(runtime).antgNumber<Int>()) { str.evaluate(runtime) }.joinToString(
             separator = separator.evaluate(
                 runtime
             )
@@ -93,7 +95,7 @@ class Standard(val runtime: Runtime) {
         val leftStr = a.evaluate(runtime)
         val rightStr = b.evaluate(runtime)
 
-        val integers = (leftStr.toIntOrNull() to rightStr.toIntOrNull())
+        val integers = (leftStr.antgNumberOrNull<Int>() to rightStr.antgNumberOrNull<Int>())
 
         // If both operands are integers, perform a numerical comparison
         if (!integers.hasNullEntry())
@@ -115,7 +117,7 @@ class Standard(val runtime: Runtime) {
         val leftStr = a.evaluate(runtime)
         val rightStr = b.evaluate(runtime)
 
-        val integers = (leftStr.toIntOrNull() to rightStr.toIntOrNull())
+        val integers = (leftStr.antgNumberOrNull<Int>() to rightStr.antgNumberOrNull<Int>())
 
         // If both operands are integers, perform a numerical comparison
         if (!integers.hasNullEntry())


### PR DESCRIPTION
This patch lays the groundwork for #13 by implementing support for parsing floating point literals. From now on, the runtime also differentiates between doubles and integer literals.