### PR TITLE
Dynamic compiler invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Anterogradia.invokeCompiler(input).use { input, output, except ->
 The `invokeCompiler` method takes an optional `parameters` argument, which is a `HashMap<String, String>` of
 startup parameters that will be accessible to the script at runtime.
 
-## Working with Anterogradia - Basic Concepts
+## Core Principles of Anterogradia
 
-1) All data types are strings. Integer literals are syntactically allowed,
+1) All data types are strings. Integer and floating point literals are syntactically allowed,
    but are treated indifferently from a regular string literal.
 
 2) There are just two types of expressions: **String literals** and **Function calls**.
@@ -65,18 +65,23 @@ startup parameters that will be accessible to the script at runtime.
    imported by default.
 
 6) A function that is not a part of the standard library must be prefixed with the prefix of the library that it belongs
-   to. In the above example,
-   the functions `set` and `get` belong to the `Memory` library with the `mem` prefix and must therefore be prefixed
-   accordingly. Also, the prefix-free
-   namespace is reserved exclusively for the standard library.
+   to. In the above example, the function `endl` belongs to the `ASCII` library imported with the `ascii` prefix and must
+   therefore be prefixed accordingly. Also, the prefix-free namespace is reserved exclusively for the standard library.
 
 7) There are two types of functions: **Variadic** and **Discrete**. The former take an arbitrary number of unnamed
    parameters, discrete functions
    have a fixed number of arguments that must explicitly be assigned by name. Therefore, however, the ordering of the
    arguments does not matter.
    Discrete functions use parentheses `( .. )` and variadic functions use curly brackets `{ .. }` for their bodies (see
-   difference between `sequence` and `if`
+   difference between `sequence` and `repeat`
    in the example above).
+
+8) Difficult and unpleasant function syntax is sometimes abstracted away with **Syntax bindings** (more on them below).
+   It is very tempting to think of these constructs as the flow control constructs we know from many modern programming
+   languages, yet we shall not forget about point number **1**, namely that, say, an if expression is not a valid AST
+   element in ANTG. All syntax _bindings_ are called that for a reason: They are just _bindings_, that is, fancy syntax,
+   for function calls. It may well be worth it to take a look at a completely pure piece of ANTG source without syntax
+   bindings to get a better understanding of the concept. You might want to take a look at the `astd` function for that.
 
 ## Importing Libraries
 
@@ -96,7 +101,7 @@ consecutively after each-other, i.e.
 @library "org.medaware.anterogradia.libs.FormattingLib" as fmt
 
 sequence {
-...
+    ...
 ```
 
 ## Standard Library
@@ -200,6 +205,14 @@ Below is a brief documentation of all the standard lib functions
 | get                                         | key           |
 |---------------------------------------------|---------------|
 | Retrieves the value of an existing variable | variable name |
+
+---
+
+### compile
+
+| compile                                                         | source               |
+|-----------------------------------------------------------------|----------------------|
+| Invokes the ANTG compiler with the current runtime and 'source' | ANTG Code to compile |
 
 ---
 

--- a/concept.antg
+++ b/concept.antg
@@ -17,4 +17,12 @@ progn {
         `length := 100
         eval makeProgress
     }
+
+    compile (source = sequence {
+        `sequence `{
+            `ascii`:`quo`(`)
+            astd(expr = "Hello, World!")
+            `ascii`:`quo`(`)
+        `}
+    })
 }

--- a/src/main/kotlin/org/medaware/anterogradia/Anterogradia.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/Anterogradia.kt
@@ -1,5 +1,6 @@
 package org.medaware.anterogradia
 
+import org.medaware.anterogradia.exception.AntgRuntimeException
 import org.medaware.anterogradia.runtime.Runtime
 import org.medaware.anterogradia.syntax.parser.Parser
 import java.nio.file.Files
@@ -13,8 +14,14 @@ import java.util.logging.LogRecord
 import java.util.logging.Logger
 import java.util.logging.SimpleFormatter
 
-data class AnterogradiaResult(val input: String, val output: String, val exception: Exception? = null, val dump: String) {
-    fun <T> use(lambda: (input: String, output: String, except: Exception?, dump: String) -> T) = lambda(input, output, exception, dump)
+data class AnterogradiaResult(
+    val input: String,
+    val output: String,
+    val exception: Exception? = null,
+    val dump: String
+) {
+    fun <T> use(lambda: (input: String, output: String, except: Exception?, dump: String) -> T) =
+        lambda(input, output, exception, dump)
 }
 
 object Anterogradia {
@@ -33,12 +40,19 @@ object Anterogradia {
         logger.useParentHandlers = false
     }
 
-    fun invokeCompiler(input: String, parameters: HashMap<String, String> = hashMapOf()): AnterogradiaResult {
+    fun invokeCompiler(
+        input: String,
+        parameters: HashMap<String, String>? = null,
+        antgRuntime: Runtime? = null
+    ): AnterogradiaResult {
+        if (parameters != null && antgRuntime != null || parameters == null && antgRuntime == null)
+            throw AntgRuntimeException("Either the runtime parameter or the runtime itself has to be provided.")
+
         var result: String
         var except: Exception? = null
         var dump = ""
 
-        val runtime = Runtime(parameters)
+        val runtime = antgRuntime ?: Runtime(parameters!!)
 
         try {
             val script = Parser.parseScript(input)

--- a/src/main/kotlin/org/medaware/anterogradia/libs/Standard.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/libs/Standard.kt
@@ -1,9 +1,11 @@
 package org.medaware.anterogradia.libs
 
+import org.medaware.anterogradia.Anterogradia
 import org.medaware.anterogradia.exception.AntgRuntimeException
 import org.medaware.anterogradia.hasNonNullEntry
 import org.medaware.anterogradia.hasNullEntry
 import org.medaware.anterogradia.map
+import org.medaware.anterogradia.rootCause
 import org.medaware.anterogradia.runtime.Runtime
 import org.medaware.anterogradia.runtime.library.AnterogradiaLibrary
 import org.medaware.anterogradia.runtime.library.DiscreteFunction
@@ -157,4 +159,14 @@ class Standard(val runtime: Runtime) {
 
         throw AntgRuntimeException(err.evaluate(runtime))
     }
+
+    @DiscreteFunction(identifier = "compile", params = ["source"])
+    fun compile(source: Node): String = Anterogradia.invokeCompiler(source.evaluate(runtime), antgRuntime = runtime)
+        .use { input, output, except, dump ->
+            if (except != null)
+                throw AntgRuntimeException("Error occurred while evaluating compile expression: ${except.rootCause().message}")
+
+            return@use output
+        }
+
 }

--- a/src/main/kotlin/org/medaware/anterogradia/runtime/library/LibraryManager.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/runtime/library/LibraryManager.kt
@@ -146,10 +146,15 @@ class LibraryManager {
             if (variadicFunctions.size != 1)
                 throw FunctionCallException("There is more than one variadic function of the same name ('${name}'). This should never happen!")
 
-            val params = args.values.toTypedArray()
+            val paramsList = mutableListOf<Node>()
+
+            args.keys.map { it.toInt() }.sorted().forEach {
+                paramsList.add(args[it.toString()]!!)
+            }
+
             val instance = runtime.libInstance(lib)
 
-            return variadicFunctions.first().first.invoke(instance, params) as String
+            return variadicFunctions.first().first.invoke(instance, paramsList.toTypedArray()) as String
         }
 
         if (variadic)


### PR DESCRIPTION
This patch implements the `compile` function which allows for dynamically invoking the compiler with a given source string. It also adapts some of the documentation to the most recent version of ANTG.