### PR TITLE
Various Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ progn {
       `length := 10
       eval makeProgress
 
-      ascii:endl()
+      ascii.endl()
 
       `length := 100
       eval makeProgress

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "org.medaware"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
     mavenCentral()

--- a/concept.antg
+++ b/concept.antg
@@ -1,14 +1,9 @@
-progn {
-   fun makeProgress <length> {
-      `bar := sequence {
-         `[repeat (count = &`length, str = "=")`]
-      }
-      &`bar
+astd(expr = progn {
+   fun doStuff <a, b, c> {
+      sequence { &`a &`b &`c }
    }
 
    sequence {
-      eval makeProgress(length = 10)
-      ascii.endl()
-      eval makeProgress(length = 100)
+      eval doStuff(a = "He", b = "llo, ", c = "World!")
    }
-}
+})

--- a/concept.antg
+++ b/concept.antg
@@ -1,4 +1,14 @@
 progn {
-    `abc := 123
-    signflp(expr = &`abc)
+   fun makeProgress <length> {
+      `bar := sequence {
+         `[repeat (count = &`length, str = "=")`]
+      }
+      &`bar
+   }
+
+   sequence {
+      eval makeProgress(length = 10)
+      ascii.endl()
+      eval makeProgress(length = 100)
+   }
 }

--- a/src/main/kotlin/org/medaware/anterogradia/libs/Standard.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/libs/Standard.kt
@@ -151,7 +151,10 @@ class Standard(val runtime: Runtime) {
 
     @DiscreteFunction(identifier = "_eval", params = ["id"])
     fun _eval(id: Node): String {
-        return (storedFunctions[id.evaluate(runtime)] ?: return "").evaluate(runtime)
+        val stored = storedFunctions[id.evaluate(runtime)]
+        if (stored == null)
+            throw AntgRuntimeException("Could not find stored function '${id.evaluate(runtime)}'.")
+        return stored.evaluate(runtime)
     }
 
     @DiscreteFunction(identifier = "__require_prop", params = ["id", "err"])

--- a/src/main/kotlin/org/medaware/anterogradia/syntax/tokenizer/TokenType.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/syntax/tokenizer/TokenType.kt
@@ -32,6 +32,7 @@ enum class TokenType(val value: String? = null) {
     HAT("^"),
     AT("@"),
     HASH("#"),
+    DOT("."),
     EXCLAMATION("!"),
 
     // Complex tokens


### PR DESCRIPTION
Change the library function prefix to a dot (`.`) - The previously used colon (`:`) is less
readable in comparison.

This patch also introduces a syntax binding which allows for inline-declarations of properties before a 'stored-expression' call, such that
```js
eval doStuff(a = "He", b = "llo, ", c = "World!")
```
expands to
```js
progn {
    set(value = "He", key = "a"),
    set(value = "llo, ", key = "b"),
    set(value = "World!", key = "c"),
    _eval(id = "doStuff")
}
```