### PR TITLE
Fix expression parsing bugs

### DIFF
--- a/concept.antg
+++ b/concept.antg
@@ -1,9 +1,1 @@
-progn {
-   fun doStuff <a, b, c> {
-      sequence { &`a &`b &`c }
-   }
-
-   sequence {
-      eval doStuff(a = "He", b = "llo, ", c = "World!")
-   }
-}
+| 1 = | "B" | | = 4

--- a/src/main/kotlin/org/medaware/anterogradia/syntax/tokenizer/TokenType.kt
+++ b/src/main/kotlin/org/medaware/anterogradia/syntax/tokenizer/TokenType.kt
@@ -36,7 +36,7 @@ enum class TokenType(val value: String? = null) {
     EXCLAMATION("!"),
 
     // Complex tokens
-    ASSIGN_RIGHT(":=");
+    ASSIGN_RIGHT(":=")
 }
 
 fun findMatchingType(str: String): TokenType? {


### PR DESCRIPTION
This patch fixes #20. Thus, expressions like the following are now successfully parsed
```js
| 1 = | "B" | | = 4
```